### PR TITLE
Fixes the package when using config:cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Lavarel Kickbox Validator
+# Lavarel Kickbox Validator
 [![Packagist](https://img.shields.io/packagist/v/stuyam/laravel-kickbox-validator.svg)](https://packagist.org/packages/stuyam/laravel-kickbox-validator)
 [![Packagist](https://img.shields.io/packagist/dt/stuyam/laravel-kickbox-validator.svg)](https://packagist.org/packages/stuyam/laravel-kickbox-validator)
 
@@ -7,31 +7,31 @@ This custom validator for Laravel uses the [kickbox.io](https://kickbox.io/) API
 
 Also see: [Laravel Twilio Validator](https://github.com/stuyam/laravel-twilio-validator) for phone number validation.
 
-###Step 1
+## Step 1
 Install via composer:
 
 ```
 composer require stuyam/laravel-kickbox-validator
 ```
 
-###Step 2
+## Step 2
 Add to your ```config/app.php``` service provider list:
 
 ```php
 StuYam\KickboxValidator\KickboxValidatorServiceProvider::class
 ```
 
-###Step 3
+## Step 3
 Add Kickbox credentials to your .env file:
 
 ```
 KICKBOX_API_KEY=xxxxxxxxxx
 ```
 
-###Step 4 (optional)
+## Step 4 (optional)
 Publish the kickbox config with `php artisan vendor:publish --tag=kickbox`
 
-###Usage
+## Usage
 Add the string 'kickbox' to a form request rules or validator like so:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Add Kickbox credentials to your .env file:
 KICKBOX_API_KEY=xxxxxxxxxx
 ```
 
+###Step 4 (optional)
+Publish the kickbox config with `php artisan vendor:publish --tag=kickbox`
 
 ###Usage
 Add the string 'kickbox' to a form request rules or validator like so:

--- a/src/KickboxValidatorServiceProvider.php
+++ b/src/KickboxValidatorServiceProvider.php
@@ -15,6 +15,11 @@ class KickboxValidatorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // allow publishing off the config
+        $this->publishes([
+            __DIR__.'/config/kickbox.php' => config_path('kickbox.php'),
+        ], 'kickbox');
+
         // load translation files
         $this->loadTranslationsFrom(__DIR__ . '/lang', 'kickbox');
 
@@ -25,14 +30,18 @@ class KickboxValidatorServiceProvider extends ServiceProvider
 
             // setup custom kickbox validator
             $validator->extend('kickbox', function($attribute, $value, $parameters, $validator){
+
+                // fetch the api key from the config - which allows the config to be cached
+                $kickboxApiKey = config('kickbox.api_key');
+
                 // throw exception if the kickbox credentials are missing from the env
-                if( env('KICKBOX_API_KEY') == null ) {
+                if( $kickboxApiKey == null ) {
                     // throw the custom exception defined below
                     throw new KickboxCredentialsNotFoundException('Please provide a KICKBOX_API_KEY in your .env file.');
                 }
 
                 // get kickbox key from users env file
-                $client = new Kickbox(env('KICKBOX_API_KEY', 'key'));
+                $client = new Kickbox($kickboxApiKey);
                 return $client->kickbox()->verify($value)->body['result'] !== 'undeliverable';
             }, $translator->get('kickbox::validation.kickbox'));
 
@@ -46,6 +55,8 @@ class KickboxValidatorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/kickbox.php', 'kickbox'
+        );
     }
 }

--- a/src/config/kickbox.php
+++ b/src/config/kickbox.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'api_key' => env('KICKBOX_API_KEY')
+];


### PR DESCRIPTION
You cannot use `env()` inside your application code when using cached
configs - which is outlined here
https://laravel.com/docs/5.4/configuration#configuration-caching

By externalising the `env(‘KICKBOX_API_KEY’)` to a config variable, it
allows it to be cached by laravel.